### PR TITLE
Reduce log noise

### DIFF
--- a/bess_controller/src/controller/control_component.go
+++ b/bess_controller/src/controller/control_component.go
@@ -47,7 +47,7 @@ func chargingControlComponentThatAllowsMoreCharge(name string, power float64) co
 	}
 }
 
-// dischargingControlComponentThatAllowsMoreCharge returns a control component which charges at the given power level (which must be positive to indicate a discharge), and
+// dischargingControlComponentThatAllowsMoreDischarge returns a control component which discharges at the given power level (which must be positive to indicate a discharge), and
 // also allows any lower-priority components that wish to discharge even faster to do so. It doesn't allow lower-priority components to discharge at a slower rate or to charge.
 func dischargingControlComponentThatAllowsMoreDischarge(name string, power float64) controlComponent {
 

--- a/bess_controller/src/controller/controller.go
+++ b/bess_controller/src/controller/controller.go
@@ -263,8 +263,8 @@ func (c *Controller) SitePower() float64 {
 type prioritisedAction struct {
 	bessTargetPower         float64           // the power that the bess should deliver
 	constraints             activeConstraints // any constraints that were used when calculating the `bessTargetPower` (useful for logging)
-	effectiveComponentNames string            // comma-separated names of any components that were used to calculate the `bessTargetPower` (useful for logging)
-	activeComponentNames    string            // comma-separated names of any components that were "active" - but they don't neccesarily effect the power
+	effectiveComponentNames string            // comma-separated names of any components that influenced the calculation of `bessTargetPower` (useful for logging)
+	activeComponentNames    string            // comma-separated names of any components that were "active" - i.e. wanted to influence the calculation of `bessTargetPower` - even if they didn't actually effect it (useful for logging)
 }
 
 // prioritiseControlComponents runs through all the given components and decides the appropriate action to take.


### PR DESCRIPTION
The bess-controller uses prioritised 'control modes' to determine what to do.

Export avoidance is quite a low-priority control mode, but it is causing a lot of noise in the logs due to messages saying `Component's max target power puts the current power out of bounds` - see example below.

The actual behaviour of the controller is correct - the logs are just a bit confusing. This PR updates the logging behaviour to make it clearer what control components are actually effecting the behaviour, and removes the noisy log line as it's not really an error but the expected operation of the algorithm.

```
Aug 09 21:30:03 hmce-revpi bess_controller_rpi[2232462]: time=2025-08-09T21:30:03.834Z level=INFO msg="INFO Using previous settlement periods imbalance data as predictor"
Aug 09 21:30:03 hmce-revpi bess_controller_rpi[2232462]: time=2025-08-09T21:30:03.834Z level=INFO msg="INFO NIV chasing debug target_energy_delta=0 target_power=0 time_left=0.4989348758311111 charge_price=1.6839999999999997 discharge_price=-1.113 imbalance_direction=long shifted_charge_price=1.6839999999999997 shifted_discharge_price=-1.113 charge_distance=-95.57600000000002 discharge_distance=NaN"
**Aug 09 21:30:03 hmce-revpi bess_controller_rpi[2232462]: time=2025-08-09T21:30:03.834Z level=ERROR msg="Component's max target power puts the current power out of bounds - ignoring" target_power=140.7099731312222 component_min_power=11.389640924740831 component_name=export_avoidance
Aug 09 21:30:03 hmce-revpi bess_controller_rpi[2232462]: time=2025-08-09T21:30:03.834Z level=INFO msg="Controlling BESS" site_power=-129.47412109375 bess_soe=1250.876 control_components_active=,discharge_to_soe,export_avoidance constraint_site_power_active=false constraint_bess_power_active=false constraint_bess_soe_active=false rates_import=2.8339999999999996 rates_export=-0.037 bess_last_target_power=140.86376201849083 bess_target_power=140.7099731312222
Aug 09 21:30:07 hmce-revpi bess_controller_rpi[2232462]: time=2025-08-09T21:30:07.833Z level=INFO msg="INFO Using previous settlement periods imbalance data as predictor"
Aug 09 21:30:07 hmce-revpi bess_controller_rpi[2232462]: time=2025-08-09T21:30:07.833Z level=INFO msg="INFO NIV chasing debug target_energy_delta=0 target_power=0 time_left=0.49782397411972223 charge_price=1.6839999999999997 discharge_price=-1.113 imbalance_direction=long shifted_charge_price=1.6839999999999997 shifted_discharge_price=-1.113 charge_distance=-95.57600000000002 discharge_distance=NaN"
**Aug 09 21:30:07 hmce-revpi bess_controller_rpi[2232462]: time=2025-08-09T21:30:07.833Z level=ERROR msg="Component's max target power puts the current power out of bounds - ignoring" target_power=140.8143538510576 component_min_power=11.414212022823762 component_name=export_avoidance
Aug 09 21:30:07 hmce-revpi bess_controller_rpi[2232462]: time=2025-08-09T21:30:07.833Z level=INFO msg="Controlling BESS" site_power=-129.29576110839844 bess_soe=1250.876 control_components_active=,discharge_to_soe,export_avoidance constraint_site_power_active=false constraint_bess_power_active=false constraint_bess_soe_active=false rates_import=2.8339999999999996 rates_export=-0.037 bess_last_target_power=140.7099731312222 bess_target_power=140.8143538510576

```